### PR TITLE
Updated RabbitMQ/API and Frontend

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,3 +1,8 @@
+# environment variables  
+
+__REACT_APP_BACKEND_HOST__ host address of backend i.e. "http://localhost:3001"
+
+
 # Getting Started with Create React App
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^13.1.1",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^0.27.2",
+        "js-cookie": "^3.0.1",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "5.0.1",
@@ -10745,6 +10746,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -23926,6 +23935,11 @@
           }
         }
       }
+    },
+    "js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^13.1.1",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^0.27.2",
+    "js-cookie": "^3.0.1",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "5.0.1",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Bürgerbüro</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,7 @@
 import "./App.css";
 import axios from "axios";
 import { useEffect, useState } from "react";
+import Cookies from "js-cookie";
 
 function App() {
     const [citizen, set_citizen] = useState([]);
@@ -11,14 +12,11 @@ function App() {
     }, []);
 
     const on_click = async () => {
-        //const mock = { accessToken: "a t lol", refreshToken: "r t xd" };
-        //localStorage.setItem("tokens", JSON.stringify(mock));
-        const { accessToken, refreshToken } = JSON.parse(
-            localStorage.getItem("tokens")
-        );
+        Cookies.set("accessToken", "ac");
+        Cookies.set("refreshToken", "rf");
         const auth_header = {
-            access_token: accessToken,
-            refresh_token: refreshToken,
+            access_token: Cookies.get("accessToken"),
+            refresh_token: Cookies.get("refreshToken"),
         };
         axios
             .get("http://localhost:3001/test", {
@@ -28,6 +26,18 @@ function App() {
             })
             .then((res) => {
                 console.log(res.data);
+            })
+            .catch((obj) => {
+                console.log(obj.response.data);
+            });
+    };
+
+    const on_click_mock = async () => {
+        axios
+            .get("http://localhost:3001/test/mock")
+            .then((res) => {
+                console.log(res.data);
+                window.location.reload(false);
             })
             .catch((obj) => {
                 console.log(obj.response.data);
@@ -57,6 +67,7 @@ function App() {
                 </tbody>
             </table>
             <button onClick={on_click}>test auth</button>
+            <button onClick={on_click_mock}>add mock data</button>
         </div>
     );
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,9 +6,11 @@ import Cookies from "js-cookie";
 function App() {
     const [citizen, set_citizen] = useState([]);
     useEffect(() => {
-        axios.get("http://localhost:3001/citizen").then((res) => {
-            set_citizen(res.data);
-        });
+        axios
+            .get(`${process.env.REACT_APP_BACKEND_HOST}/citizen`)
+            .then((res) => {
+                set_citizen(res.data);
+            });
     }, []);
 
     const on_click = async () => {
@@ -19,7 +21,7 @@ function App() {
             refresh_token: Cookies.get("refreshToken"),
         };
         axios
-            .get("http://localhost:3001/test", {
+            .get(`${process.env.REACT_APP_BACKEND_HOST}/test`, {
                 headers: {
                     Authorization: JSON.stringify(auth_header),
                 },
@@ -34,7 +36,7 @@ function App() {
 
     const on_click_mock = async () => {
         axios
-            .get("http://localhost:3001/test/mock")
+            .get(`${process.env.REACT_APP_BACKEND_HOST}/test/mock`)
             .then((res) => {
                 console.log(res.data);
                 window.location.reload(false);

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -46,7 +46,7 @@ function App() {
 
     return (
         <div className="App">
-            <h1>Fundsachen</h1>
+            <h1>Bürger</h1>
             <table bgcolor="black" align="center">
                 <tbody>
                     <tr bgcolor="grey">

--- a/server/index.js
+++ b/server/index.js
@@ -62,7 +62,7 @@ db.sequelize.sync({ force: rebuild }).then(async () => {
                 console.log("consumed service.world");
             });
         } catch (error) {
-            throw error;
+            console.error(error);
         }
     });
 });

--- a/server/rabbitmq.js
+++ b/server/rabbitmq.js
@@ -1,8 +1,8 @@
 const amqp = require("amqplib");
 require("dotenv").config();
 
-const connection = amqp.connect(process.env.AMQPHOST, (error0, connecttion) => {
-    if (error0) throw error0;
+const connection = amqp.connect(process.env.AMQPHOST).catch((error) => {
+    console.error(error);
 });
 
 function connect() {

--- a/server/routes/citizen.js
+++ b/server/routes/citizen.js
@@ -54,7 +54,7 @@ router.post("/", async (req, res) => {
                 Buffer.from(JSON.stringify({ email: citizen.email }))
             );
         } catch (error) {
-            throw error;
+            console.error(error);
         }
 
         res.status(201).json(citizen);

--- a/server/routes/test.js
+++ b/server/routes/test.js
@@ -4,10 +4,16 @@ const db = require("../models");
 const rabbitmq = require("../rabbitmq");
 const { auth } = require("../middlewares/auth");
 require("dotenv").config();
+const { create_mockdata } = require("../mockdata");
 
 router.get("/", auth, async (req, res) => {
     console.log("test auth");
     res.send("OK");
+});
+
+router.get("/mock", async (req, res) => {
+    await create_mockdata(5);
+    res.send("mockdata created");
 });
 
 module.exports = router;


### PR DESCRIPTION
- stop app crash wenn rabbitmq errors (keine connection, keine/falsche exchange
- benutze jetzt cookies für tokes
- man kann jetzt (bürger) mock daten über knopfdruck hinzufügen